### PR TITLE
docs: What's New + Changelog entry for CI & deployment improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Deployment & CI (2026-01-13)
+
+- **Resilient push fallbacks**: `scripts/build-and-deploy.sh` now attempts an ordered series of push fallbacks when the configured registry is unreachable:
+  - Primary: configured registry (from `deploy/config.env` or `REGISTRY`)
+  - Fallback 1: GHCR (when `GHCR_PAT` is available; `GHCR_OWNER`/`GHCR_USER` optional)
+  - Fallback 2: Node-import (`NODE_IMPORT_NODES` comma-separated list, uses `scripts/load-image-to-cluster.sh`)
+  - Added `SKIP_DEPLOY=1` for local/test runs to skip Kubernetes steps
+- **Local CI hardening**: `scripts/ci-local.sh` will skip `uv sync` when private extras (e.g., `cloud-private`) are declared unless `INCLUDE_PRIVATE_EXTRAS=1` is set; this prevents spurious uv resolution failures for contributors without access to private package indexes.
+- **Tests & tooling**: Added integration tests verifying GHCR and node-import fallback behavior and added `scripts/load-image-to-cluster.sh` for node-import workflows.
+- **Docs**: Updated `docs/REGISTRY_TROUBLESHOOTING.md` and `docs/DEPENDENCY_MANAGEMENT.md` with fallback procedures and guidance for private extras.
+
 #### UI/UX
 
 - Web UI polish: Lucide icons via shared macro, centralized utilities in `voxel-dark.css`, class-based visibility helpers, and accessibility labels across montage and shorts templates.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Input Footage → Analysis → Creative Direction → Editing → Enhancement �
 
 - **[Getting Started](docs/getting-started.md)** — Installation & first project
 - **[Features](docs/features.md)** — Complete capabilities guide
+- **What's new:** **[Recent updates & operational notes](docs/WHATS_NEW.md)** — Deployment, CI, and fallback updates
 - **[Configuration](docs/configuration.md)** — All settings & environment variables
 - **[Architecture](docs/architecture.md)** — How it works (for developers)
 - **[Parameter Reference](docs/PARAMETER_REFERENCE.md)** — All controllable parameters

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,0 +1,29 @@
+# What's New (2026-01-13)
+
+This page highlights recent operational and CI improvements that make builds and canary deploys more resilient and easier for contributors without access to private indexes.
+
+## Key updates
+
+- Resilient push fallbacks
+  - The `scripts/build-and-deploy.sh` script now attempts push fallbacks when the configured registry is unreachable:
+    1. Primary: configured registry (from `deploy/config.env` / `REGISTRY`)
+    2. Fallback: GHCR (when `GHCR_PAT` is provided)
+    3. Fallback: Node-import via `scripts/load-image-to-cluster.sh` (when `NODE_IMPORT_NODES` is set)
+  - Use `SKIP_DEPLOY=1` for local/test runs to skip Kubernetes steps.
+
+- Local CI stability
+  - `scripts/ci-local.sh` now skips `uv sync` by default when private extras (e.g., `cloud-private`) are declared to avoid failing on developer machines without private indexes. Set `INCLUDE_PRIVATE_EXTRAS=1` to opt-in.
+
+- Power-user tools
+  - `scripts/check-registry.py` and `scripts/registry_check.sh` provide quick diagnostics for registry reachability and TLS checks.
+  - `scripts/load-image-to-cluster.sh` provides an example node-import flow (scp tar to node(s) + `ctr images import`) for environments where registry push is not available.
+
+- Tests and docs
+  - Added integration tests that simulate registry push failure and verify GHCR and node-import fallbacks.
+  - Updated `docs/REGISTRY_TROUBLESHOOTING.md` and `docs/DEPENDENCY_MANAGEMENT.md` with the new workflow and guidance.
+
+## How this helps contributors
+- Contributors without private index access can still run local CI and tests reliably.
+- Ops can choose to enable the internal registry or accept fallbacks (GHCR or node-import) depending on policy.
+
+For the full list of changes see `CHANGELOG.md` under **Unreleased**.


### PR DESCRIPTION
Adds a concise 'What's New' doc highlighting deployment/CI resilience improvements and a corresponding entry under 'Unreleased' in CHANGELOG.md covering GHCR fallback, node-import fallback, local CI hardening, and related tests/docs updates.