### PR TITLE
docs(k8s): add DEV preview fast-path checks + quota note

### DIFF
--- a/docs/KUBERNETES_RUNBOOK.md
+++ b/docs/KUBERNETES_RUNBOOK.md
@@ -40,6 +40,29 @@ If you have ingress configured, use your own domain, for example:
 curl -H "Host: YOUR_MONTAGE_HOST" http://YOUR_INGRESS_IP/health
 ```
 
+## DEV: preview fast-path — quick validation checklist
+
+When validating the **preview** fast-path (distributed overlay) in DEV, follow these fast checks to avoid common failures:
+
+- PVC / Quota
+  - Ensure the `montage-ai` namespace has sufficient `ResourceQuota` for `persistentvolumeclaims` **and** `requests.storage`. The `distributed` overlay creates several NFS PVCs and will fail if the quota is exceeded (pods remain `Pending`).
+  - Short-term workaround: reuse existing `montage-*-rwx` PVCs in DEV to validate functionality without provisioning new volumes.
+
+- Minimal smoke fixtures
+  - Copy two small test clips to `/data/input/` and a short WAV (>= 3–4s) to `/data/music/` on the input PVC before running the smoke.
+
+- Run the opt-in smoke
+
+```bash
+# run from a machine that can reach the DEV ingress
+./scripts/ci/preview-benchmark.sh BASE=https://<dev-host> RUNS=5
+curl -sS https://<dev-host>/metrics | grep montage_time_to_preview_seconds || true
+```
+
+- Expected DEV SLO (starter): p50 < 8s, p95 < 30s (use the Grafana preview_slo dashboard for visual checks).
+
+See `patches/infra/2026-01-22-dev-distributed-deploy-report.md` for a recent deployment attempt and remediation steps.
+
 ## Escalation
 
 If these steps do not resolve the issue, gather the pod logs/events and open an issue with the details.


### PR DESCRIPTION
Adds a short DEV validation checklist for the preview fast-path (quota, minimal fixtures, opt-in smoke). References recent deployment report (patches/infra/2026-01-22-dev-distributed-deploy-report.md). Recommended small cleanup to help infra debug the DEV rollout.