### PR TITLE
Fix: Docker Web UI port mismatch (5000 → 8080)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,8 @@ RUN groupadd -g ${GID} montage && \
     useradd -u ${UID} -g ${GID} -m -s /bin/bash montage && \
     chown -R montage:montage /app
 
-# Expose port for web UI
-# Allow override via build-arg/service config; default kept as 5000 for backwards compatibility
-ARG SERVICE_PORT=5000
+# Expose port for web UI (must match Flask app port in app.py, default 8080)
+ARG SERVICE_PORT=8080
 EXPOSE ${SERVICE_PORT}
 ENV SERVICE_PORT=${SERVICE_PORT}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: montage-ai:latest
     container_name: montage-ai
     ports:
-      - "${WEB_PORT:-8080}:5000"
+      - "${WEB_PORT:-8080}:8080"
     # === RESOURCE LIMITS - CRITICAL FOR STABILITY ===
     # ⚠️  These limits prevent the container from consuming all system resources.
     #


### PR DESCRIPTION
## 🐛 Fix: Docker Web UI Port Mismatch

### Problem
The Docker configuration had a **critical port mismatch** that prevented the Web UI from being accessible:

- **Dockerfile** exposed port `5000` (default for backwards compatibility)
- **docker-compose.yml** mapped external port → container port `5000`  
- **Flask app** (`src/montage_ai/web_ui/app.py`) runs on port `8080`

**Result:** Web UI unreachable at `http://localhost:8080`

### Solution
Fixed port mappings to align with Flask app default:
1. **Dockerfile**: Changed `EXPOSE` from `5000` → `8080`
2. **docker-compose.yml**: Updated port mapping from `:5000` → `:8080`

### Verification ✅

**Local Docker:**
```bash
docker compose build
WEB_PORT=8081 docker compose up
curl http://localhost:8081  # ✓ SUCCESS
```

**K3s Cluster:**
```bash
make -C deploy/k3s config
./build-and-push.sh  # Multi-arch image
./deploy.sh cluster
kubectl port-forward -n montage-ai svc/montage-ai-web 8082:80
curl http://localhost:8082  # ✓ SUCCESS
```

**Full Clean Install Test Passed:**
- ✅ Local Docker Compose deployment
- ✅ K3s/Kubernetes cluster deployment
- ✅ Multi-arch image build (linux/amd64, linux/arm64)
- ✅ Storage & PVCs working
- ✅ Web UI accessible on both environments
- ✅ CLI tools working
- ✅ Preview rendering pipeline functional

### Related
- Closes #36
- Full clean installation validation (Feb 9, 2026)